### PR TITLE
Fix two seeds example

### DIFF
--- a/vignettes/sitmo_internals.Rmd
+++ b/vignettes/sitmo_internals.Rmd
@@ -246,9 +246,9 @@ This example displays the ability of `sitmo` to handle parallel streams of rng w
 //' @return A \code{matrix} with random sequences. 
 //' @examples
 //' n = 10
-//' a = sitmo_engine_seed(n, c(1337,1338))
+//' a = sitmo_two_seeds(n, c(1337,1338))
 //' 
-//' b = sitmo_engine_seed(n, c(1337,1337))
+//' b = sitmo_two_seeds(n, c(1337,1337))
 //' 
 //' isTRUE(all.equal(a[,1],a[,2]))
 //' 
@@ -261,14 +261,14 @@ Rcpp::NumericMatrix sitmo_two_seeds(unsigned int n, Rcpp::NumericVector seeds) {
   if(seeds.size() != 2) Rcpp::stop("Need exactly two seeds for this example.");
   
   // Create Rcpp Matrix
-  Rcpp::NumericMatrix o(n,3);
+  Rcpp::NumericMatrix o(n,2);
   
   // Create a prng engine with a specific seed
   sitmo::prng_engine eng1;
   eng1.seed(seeds(0));
   
   sitmo::prng_engine eng2;
-  eng1.seed(seeds(1));
+  eng2.seed(seeds(1));
 
   // Draw from base engine
   for (unsigned int i=0; i< n ; ++i){


### PR DESCRIPTION
The example used a function from another demo, the matrix of results had one extra column, and no seed was used for second engine.